### PR TITLE
remove the domain after parse the domain.

### DIFF
--- a/Pod/Classes/pili-librtmp/parseurl.c
+++ b/Pod/Classes/pili-librtmp/parseurl.c
@@ -137,11 +137,12 @@ parsehost:
     if (domainName != NULL && ques != NULL) {
         char *domain = strstr(ques, "domain=");
         if (domain) {
+            end = domain - 1;
             domain += 7; //skip "domain="
-            char *end = strchr(domain, '&');
+            char *domain_end = strchr(domain, '&');
             int host_len = 0;
-            if (end) {
-                host_len = end - domain;
+            if (domain_end) {
+                host_len = domain_end - domain;
             } else {
                 host_len = strlen(domain);
             }


### PR DESCRIPTION
https://github.com/pili-engineering/PLPlayerKit/issues/140
地址是rtmp://139.129.85.12:1935/live/1001

解析完 domain 后，将其删除，以免影响播放。
