### PR TITLE
stat the bytes received and sent

### DIFF
--- a/Pod/Classes/pili-librtmp/rtmp.c
+++ b/Pod/Classes/pili-librtmp/rtmp.c
@@ -1479,9 +1479,6 @@ static int
 #ifdef CRYPTO
     char *encrypted = 0;
     char buf[RTMP_BUFFER_CACHE_SIZE];
-  
-    // @remark debug info by http://github.com/ossrs/srs
-    _srs_sbytes += n;
 
     if (r->Link.rc4keyOut) {
         if (n > sizeof(buf))
@@ -1492,6 +1489,9 @@ static int
         RC4_encrypt2(r->Link.rc4keyOut, n, buffer, ptr);
     }
 #endif
+  
+    // @remark debug info by http://github.com/ossrs/srs
+    _srs_sbytes += n;
 
 #ifdef RTMP_FEATURE_NONBLOCK
     SET_RCVTIMEO(tv, r->Link.timeout);

--- a/Pod/Classes/pili-librtmp/rtmp.c
+++ b/Pod/Classes/pili-librtmp/rtmp.c
@@ -1343,6 +1343,10 @@ extern FILE *netstackdump;
 extern FILE *netstackdump_read;
 #endif
 
+// @remark debug info by http://github.com/ossrs/srs
+unsigned long _srs_rbytes = 0;
+unsigned long _srs_sbytes = 0;
+
 static int
     ReadN(PILI_RTMP *r, char *buffer, int n) {
     int nOriginalSize = n;
@@ -1354,6 +1358,9 @@ static int
 #ifdef _DEBUG
     memset(buffer, 0, n);
 #endif
+  
+    // @remark debug info by http://github.com/ossrs/srs
+    _srs_rbytes += n;
 
     ptr = buffer;
     while (n > 0) {
@@ -1472,6 +1479,9 @@ static int
 #ifdef CRYPTO
     char *encrypted = 0;
     char buf[RTMP_BUFFER_CACHE_SIZE];
+  
+    // @remark debug info by http://github.com/ossrs/srs
+    _srs_sbytes += n;
 
     if (r->Link.rc4keyOut) {
         if (n > sizeof(buf))

--- a/Pod/Classes/pili-librtmp/rtmp.h
+++ b/Pod/Classes/pili-librtmp/rtmp.h
@@ -356,6 +356,22 @@ int PILI_RTMP_Version();
 int PILI_RTMP_HashSWF(const char *url, unsigned int *size, unsigned char *hash,
                       int age);
 
+/* 
+ ***********************************************************************
+ * Introduced by SRS, other useful data.
+ ***********************************************************************
+ */
+/*
+ * The received bytes from server. user can use to stat the kbps by:
+ *      rkbps = rbytes * 8 / 1000 / (diff seconds)
+ */
+extern unsigned long _srs_rbytes;
+/*
+ * The sent bytes from server. user can use to stat the kbps by:
+ *      skbps = sbytes * 8 / 1000 / (diff seconds)
+ */
+extern unsigned long _srs_sbytes;
+
 #ifdef __cplusplus
 };
 #endif


### PR DESCRIPTION
对外提供librmtp发送和接口的字节数。
貌似librtmp也有m_nBytesIn和m_nBytesInSent，是用做给服务器发送ack的，没有看懂这两个变量的处理，就加了两个全局变量。
如果librtmp已经有这个了，那就请忽略这个吧。
